### PR TITLE
Rename document to respect 50char limit

### DIFF
--- a/draft-hendrickson-privacypass-geo-extension.md
+++ b/draft-hendrickson-privacypass-geo-extension.md
@@ -3,7 +3,7 @@ title: "Privacy Pass Geolocation Hint Extension"
 abbrev: "Privacy Pass Geolocation Hint Extension"
 category: info
 
-docname: draft-hendrickson-privacypass-geolocation-extension-latest
+docname: draft-hendrickson-privacypass-geo-extension-latest
 submissiontype: IETF
 number:
 date:


### PR DESCRIPTION
The `Publish New Draft Version` action fails currently. I think I did something hacky to get the first release out.

https://github.com/chris-wood/draft-hendrickson-privacypass-geolocation-extension/actions/runs/6513230603/job/17692429980